### PR TITLE
Fix Grafana dashboard

### DIFF
--- a/src/grafana_dashboards/zinc.json.tmpl
+++ b/src/grafana_dashboards/zinc.json.tmpl
@@ -245,7 +245,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(rate(gin_requests_total{juju_model=\"$juju_model\", juju_model_uuid=\"$juju_model_uuid\", juju_application=\"$juju_application\"}[2m])) OR on() vector(0)",
+          "expr": "sum(count_over_time(gin_requests_total{juju_model=\"$juju_model\", juju_model_uuid=\"$juju_model_uuid\", juju_application=\"$juju_application\"}[2m])) OR on() vector(0)",
           "interval": "",
           "legendFormat": "",
           "queryType": "randomWalk",

--- a/src/grafana_dashboards/zinc.json.tmpl
+++ b/src/grafana_dashboards/zinc.json.tmpl
@@ -467,7 +467,7 @@
       "pluginVersion": "8.1.1",
       "targets": [
         {
-          "expr": "sum(rate({juju_model=\"$juju_model\", juju_model_uuid=\"$juju_model_uuid\", juju_application=\"$juju_application\"}[1m]))",
+          "expr": "count_over_time({juju_model=\"$juju_model\", juju_model_uuid=\"$juju_model_uuid\", juju_application=\"$juju_application\"}[1m])",
           "queryType": "randomWalk",
           "refId": "A"
         }
@@ -556,7 +556,7 @@
       "pluginVersion": "8.1.1",
       "targets": [
         {
-          "expr": "sum(rate({juju_model=\"$juju_model\", juju_model_uuid=\"$juju_model_uuid\", juju_application=\"$juju_application\"}[1m]|~ \"ERROR\"))",
+          "expr": "count_over_time({juju_model=\"$juju_model\", juju_model_uuid=\"$juju_model_uuid\", juju_application=\"$juju_application\"}[1m]|~ \"ERROR\")",
           "queryType": "randomWalk",
           "refId": "A"
         }
@@ -617,7 +617,7 @@
       "pluginVersion": "8.1.1",
       "targets": [
         {
-          "expr": "sum(rate({juju_model=\"$juju_model\", juju_model_uuid=\"$juju_model_uuid\", juju_application=\"$juju_application\"}[1m]|~ \"GIN-debug\"))",
+          "expr": "count_over_time({juju_model=\"$juju_model\", juju_model_uuid=\"$juju_model_uuid\", juju_application=\"$juju_application\"}[1m]|~ \"GIN-debug\")",
           "queryType": "randomWalk",
           "refId": "A"
         }


### PR DESCRIPTION
Before this fix we were miscalculating `Log lines /m`, `Error logs /m` and `Debuglogs /m`. There are a lot of log lines, and the value were `1`, `0` and `1`

![imagen](https://user-images.githubusercontent.com/939888/173162795-702dc457-41ae-4acc-9cd0-f63410f96f06.png)

And we were also miscalculating `HTTP Requests/min`:

![imagen](https://user-images.githubusercontent.com/939888/173163746-49c13736-e1cb-4796-929e-e5891fc12fc1.png)


With this fix:

![imagen](https://user-images.githubusercontent.com/939888/173162726-d788514e-34de-42cd-a474-1c1b65a2e79e.png)


And...

![imagen](https://user-images.githubusercontent.com/939888/173163794-b7c5bb0b-0b6b-4ac2-abd2-38f0272868f7.png)


