### PR TITLE
Version bump: Zinc 0.2.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/zinclabs/zinc:0.2.4 AS builder
+FROM public.ecr.aws/zinclabs/zinc:0.2.5 AS builder
 
 FROM ubuntu:latest
 COPY --from=builder /go/bin/zinc /go/bin/zinc

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -29,7 +29,7 @@ resources:
     type: oci-image
     description: OCI image for zinc
     # Included for simplicity in integration tests
-    upstream-source: jnsgruk/zinc:0.2.4
+    upstream-source: jnsgruk/zinc:0.2.5
 
 provides:
   metrics-endpoint:


### PR DESCRIPTION
Follow the upstream release of [version 0.2.5 ](https://github.com/zinclabs/zinc/releases/tag/v0.2.5?notification_referrer_id=NT_kwDOAAozWbEzODg0NTYwNjc4OjY2ODUwNQ)