### PR TITLE
Added alert rule to check if zinc instance is down

### DIFF
--- a/src/prometheus_alert_rules/zinc_missing.rule
+++ b/src/prometheus_alert_rules/zinc_missing.rule
@@ -1,0 +1,8 @@
+alert: ZincTargetMissing
+expr: up == 0
+for: 0m
+labels:
+  severity: critical
+annotations:
+  summary: Prometheus target missing (instance {{ $labels.instance }})
+  description: "A Prometheus target has disappeared. An exporter might be crashed.\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"


### PR DESCRIPTION
### Description

This commit adds a basic Prometheus alert rule that will trigger
if a zinc instance is down.

