### PR TITLE
Omit Juju Unit from the Dashboard Filter

### DIFF
--- a/src/grafana_dashboards/zinc.json.tmpl
+++ b/src/grafana_dashboards/zinc.json.tmpl
@@ -122,7 +122,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(up{juju_model=\"$juju_model\", juju_model_uuid=\"$juju_model_uuid\", juju_application=\"$juju_application\"}) by (juju_unit)",
+          "expr": "sum(up{juju_model=\"$juju_model\", juju_model_uuid=\"$juju_model_uuid\", juju_application=\"$juju_application\",juju_unit!=\"\"}) by (juju_unit)",
           "instant": true,
           "interval": "",
           "legendFormat": "",


### PR DESCRIPTION
The table that lists the zinc units and their statuses should not be filtered by unit, as that defeats the whole purpose. By adding this "should not be empty" filter, we prevent cos-tool from trying to be helpful and inject it for us.