### PR TITLE
Fix env variables names

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -38,8 +38,8 @@ class ZincCharm(CharmBase):
                     "startup": "enabled",
                     "environment": {
                         "DATA_PATH": "/go/bin/data",
-                        "FIRST_ADMIN_USER": "admin",
-                        "FIRST_ADMIN_PASSWORD": "#Pa55word!",
+                        "ZINC_FIRST_ADMIN_USER": "admin",
+                        "ZINC_FIRST_ADMIN_PASSWORD": "#Pa55word!",
                     },
                 }
             },


### PR DESCRIPTION
The latest version of Zinc requires `ZINC_FIRST_ADMIN_USER` and  `ZINC_FIRST_ADMIN_PASSWORD` to run. This was already fix in `main`,