### PR TITLE
Fix env variables names

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -63,8 +63,8 @@ class ZincCharm(CharmBase):
                         "startup": "enabled",
                         "environment": {
                             "DATA_PATH": "/go/bin/data",
-                            "FIRST_ADMIN_USER": "admin",
-                            "FIRST_ADMIN_PASSWORD": self._stored.initial_admin_password,
+                            "ZINC_FIRST_ADMIN_USER": "admin",
+                            "ZINC_FIRST_ADMIN_PASSWORD": self._stored.initial_admin_password,
                         },
                     }
                 },


### PR DESCRIPTION
The latest version of Zinc requires `ZINC_FIRST_ADMIN_USER` and  `ZINC_FIRST_ADMIN_PASSWORD` to run. This was already fix in `main`,