### PR TITLE
Scenario tests

### DIFF
--- a/tests/scenario/test_scenario.py
+++ b/tests/scenario/test_scenario.py
@@ -1,0 +1,81 @@
+from unittest.mock import patch
+
+import pytest
+from ops import pebble
+from scenario import State, Container, Relation
+
+from charm import ZincCharm
+
+@pytest.fixture(autouse=True, scope='function')
+def setup():
+    with patch("charm.KubernetesServicePatch"):
+        with patch.object(ZincCharm, "_request_version", lambda *_: "0.0-test"):
+            yield
+
+
+def test_nothing_happens_on_start():
+    # arrange
+    state = State()
+    # act
+    out = state.trigger('start', ZincCharm)
+    # assert
+
+    # ignore juju log and storedstate changes
+    out.juju_log = []
+    out.stored_state = state.stored_state
+    assert out.jsonpatch_delta(state) == []
+
+
+def test_pebble_ready_admin_password():
+    # arrange
+    container = Container(name='zinc', can_connect=True)
+    state = State(
+        containers=[
+            container
+        ]
+    )
+    # act
+    out = state.trigger(container.pebble_ready_event, ZincCharm)
+    # assert
+    assert out.status.unit == ('active', '')
+    env = out.get_container('zinc').layers['zinc'].services['zinc'].environment
+    stored_state = next(filter(lambda sst: sst.owner_path == 'ZincCharm', out.stored_state))
+    assert env['ZINC_FIRST_ADMIN_PASSWORD'] == stored_state.content['initial_admin_password']
+
+
+def test_update_status():
+    # arrange
+    state = State(
+        containers=[
+            Container(
+                name='zinc',
+                can_connect=True,
+                layers={
+                    'zinc': pebble.Layer(
+                        {'services': {'zinc': {'startup': 'enabled'}}}
+                    )
+                })
+        ]
+    )
+    # act
+    out = state.trigger('update_status', ZincCharm)
+    # assert
+    assert out.status.app_version == "0.0-test"
+
+
+def test_ingress_integration():
+    # arrange
+    relation = Relation("ingress", interface="ingress")
+    state = State(
+        leader=True,
+        relations=[
+            relation
+        ]
+    )
+    # act
+    out = state.trigger(relation.created_event, ZincCharm)
+    # assert
+    assert out.relations[0].local_app_data['model']
+    assert out.relations[0].local_app_data['name']
+    assert out.relations[0].local_app_data['host']
+    assert out.relations[0].local_app_data['port']

--- a/tests/scenario/test_scenario.py
+++ b/tests/scenario/test_scenario.py
@@ -1,12 +1,13 @@
+from socket import getfqdn
 from unittest.mock import patch
 
 import pytest
-from ops import pebble
-from scenario import State, Container, Relation
-
 from charm import ZincCharm
+from ops import pebble
+from scenario import Container, Model, Relation, State
 
-@pytest.fixture(autouse=True, scope='function')
+
+@pytest.fixture(autouse=True, scope="function")
 def setup():
     with patch("charm.KubernetesServicePatch"):
         with patch.object(ZincCharm, "_request_version", lambda *_: "0.0-test"):
@@ -14,11 +15,8 @@ def setup():
 
 
 def test_nothing_happens_on_start():
-    # arrange
     state = State()
-    # act
-    out = state.trigger('start', ZincCharm)
-    # assert
+    out = state.trigger("start", ZincCharm)
 
     # ignore juju log and storedstate changes
     out.juju_log = []
@@ -27,55 +25,35 @@ def test_nothing_happens_on_start():
 
 
 def test_pebble_ready_admin_password():
-    # arrange
-    container = Container(name='zinc', can_connect=True)
-    state = State(
-        containers=[
-            container
-        ]
-    )
-    # act
+    container = Container(name="zinc", can_connect=True)
+    state = State(containers=[container])
     out = state.trigger(container.pebble_ready_event, ZincCharm)
-    # assert
-    assert out.status.unit == ('active', '')
-    env = out.get_container('zinc').layers['zinc'].services['zinc'].environment
-    stored_state = next(filter(lambda sst: sst.owner_path == 'ZincCharm', out.stored_state))
-    assert env['ZINC_FIRST_ADMIN_PASSWORD'] == stored_state.content['initial_admin_password']
+    assert out.status.unit == ("active", "")
+    env = out.get_container("zinc").layers["zinc"].services["zinc"].environment
+    stored_state = next(filter(lambda sst: sst.owner_path == "ZincCharm", out.stored_state))
+    assert env["ZINC_FIRST_ADMIN_PASSWORD"] == stored_state.content["initial_admin_password"]
 
 
 def test_update_status():
-    # arrange
     state = State(
         containers=[
             Container(
-                name='zinc',
+                name="zinc",
                 can_connect=True,
-                layers={
-                    'zinc': pebble.Layer(
-                        {'services': {'zinc': {'startup': 'enabled'}}}
-                    )
-                })
+                layers={"zinc": pebble.Layer({"services": {"zinc": {"startup": "enabled"}}})},
+            )
         ]
     )
-    # act
-    out = state.trigger('update_status', ZincCharm)
-    # assert
+    out = state.trigger("update_status", ZincCharm)
     assert out.status.app_version == "0.0-test"
 
 
 def test_ingress_integration():
-    # arrange
     relation = Relation("ingress", interface="ingress")
-    state = State(
-        leader=True,
-        relations=[
-            relation
-        ]
-    )
-    # act
+    state = State(model=Model(name="mymodel"), leader=True, relations=[relation], app_name="myapp")
     out = state.trigger(relation.created_event, ZincCharm)
-    # assert
-    assert out.relations[0].local_app_data['model']
-    assert out.relations[0].local_app_data['name']
-    assert out.relations[0].local_app_data['host']
-    assert out.relations[0].local_app_data['port']
+    lappdata = out.relations[0].local_app_data
+    assert lappdata["model"] == "mymodel"
+    assert lappdata["name"] == "myapp"
+    assert lappdata["host"] == getfqdn()
+    assert lappdata["port"] == "4080"  # default

--- a/tox.ini
+++ b/tox.ini
@@ -85,3 +85,15 @@ commands =
            --ignore={[vars]tst_path}unit \
            --log-cli-level=INFO \
            {posargs}
+
+
+[testenv:scenario]
+description = Scenario tests
+deps =
+    pytest
+    ops-scenario
+    jsonpatch
+    -r{toxinidir}/requirements.txt
+commands =
+    pytest -v --tb native {toxinidir}/tests/scenario --log-cli-level=INFO -s {posargs}
+

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 skipsdist=True
 skip_missing_interpreters = True
-envlist = fmt, lint, unit
+envlist = fmt, lint, unit, scenario
 
 [vars]
 src_path = {toxinidir}/src/
@@ -57,10 +57,10 @@ deps =
 commands =
     coverage run --source={[vars]src_path} \
                  -m pytest \
-                 --ignore={[vars]tst_path}integration \
                  --tb native \
                  -v \
                  -s \
+                 {[vars]tst_path}unit \
                  {posargs}
     coverage report
 
@@ -82,8 +82,8 @@ commands =
     pytest -v \
            -s \
            --tb native \
-           --ignore={[vars]tst_path}unit \
            --log-cli-level=INFO \
+           {[vars]tst_path}integration \
            {posargs}
 
 
@@ -95,5 +95,10 @@ deps =
     jsonpatch
     -r{toxinidir}/requirements.txt
 commands =
-    pytest -v --tb native {toxinidir}/tests/scenario --log-cli-level=INFO -s {posargs}
+    pytest -v \
+           -s \
+           --tb native \
+           --log-cli-level=INFO \
+           {[vars]tst_path}scenario \
+           {posargs}
 


### PR DESCRIPTION
This PR adds a few simple scenario tests to the zinc charm.

Run them with `tox -e scenario`