### PR TITLE
Migrate to using a ROCK

### DIFF
--- a/.github/workflows/publish-oci.yaml
+++ b/.github/workflows/publish-oci.yaml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
     paths:
-      - "Dockerfile"
+      - "rockcraft.yaml"
 jobs:
   build:
     runs-on: ubuntu-22.04
@@ -13,29 +13,36 @@ jobs:
       - name: Checkout
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2
-        with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4c0219f9ac95b02789c1075625400b2acbff50b1 # v2
-
       - name: Check the version
         id: get_version
         run: |
-          version="$(grep -Po "zinc:\K[0-9]+\.[0-9]+\.[0-9]+" Dockerfile)"
+          sudo snap install yq --classic
+          version="$(yq '.version' rockcraft.yaml)"
           echo "VERSION=$version" >> $GITHUB_OUTPUT
-
-      - name: Build and push
-        uses: docker/build-push-action@2eb1c1961a95fc15694676618e422e8ba1d63825 # v4
+      
+      - id: rockcraft
+        name: Build ROCK
+        uses: canonical/craft-actions/rockcraft-pack@main
+      
+      - name: Upload ROCK artifact
+        uses: actions/upload-artifact@v3
         with:
-          context: ./
-          file: ./Dockerfile
-          builder: ${{ steps.buildx.outputs.name }}
-          push: true
-          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/zinc:${{ steps.get_version.outputs.VERSION }},${{ secrets.DOCKER_HUB_USERNAME }}/zinc:latest
+            name: zinc-rock
+            path: ${{ steps.rockcraft.outputs.rock }}
+
+      - name: Upload ROCK to ghcr.io
+        run: |
+          # Upload ROCK to ghcr.io/jnsgruk/zinc:<version>
+          sudo skopeo --insecure-policy copy \
+            "oci-archive:$(realpath ./zinc_*.rock)" \
+            "docker://ghcr.io/jnsgruk/zinc:${{ steps.get_version.outputs.VERSION }}" \
+            --dest-creds "${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}"
+
+          # Upload ROCK to ghcr.io/jnsgruk/zinc:latest
+          sudo skopeo --insecure-policy copy \
+            "oci-archive:$(realpath ./zinc_*.rock)" \
+            "docker://ghcr.io/jnsgruk/zinc:latest" \
+            --dest-creds "${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}"
 
       - name: Update charm metadata
         run: |
@@ -54,11 +61,11 @@ jobs:
         id: cpr
         with:
           token: ${{ steps.generate-token.outputs.token }}
-          commit-message: "chore(deps): bump zinc container image to `jnsgruk/zinc:${{ steps.get_version.outputs.VERSION }}`"
+          commit-message: "chore(deps): bump zinc container image to `zinc:${{ steps.get_version.outputs.VERSION }}`"
           committer: "Github Actions <github-actions@github.com>"
           author: "Github Actions <github-actions@github.com>"
-          title: "Update container image to `jnsgruk/zinc:${{ steps.get_version.outputs.VERSION }}`"
-          body: "Update container image to `jnsgruk/zinc:${{ steps.get_version.outputs.VERSION }}`"
+          title: "Update container image to `zinc:${{ steps.get_version.outputs.VERSION }}`"
+          body: "Update container image to `zinc:${{ steps.get_version.outputs.VERSION }}`"
           branch: "auto-container-${{ steps.get_version.outputs.VERSION }}"
           delete-branch: true
           reviewers: jnsgruk

--- a/.github/workflows/update-oci.yaml
+++ b/.github/workflows/update-oci.yaml
@@ -47,9 +47,11 @@ jobs:
       - name: Update version
         run: |
           # Grab the output from the last job
-          LATEST="${{ needs.check-upstream.outputs.release }}"
-          # Update the version (strip the leading 'v' from the LATEST version)
-          sed -i "s/zinc:[0-9]\+\.[0-9]\+\.[0-9]\+/zinc:${LATEST/v/}/g" Dockerfile
+          upstream="${{ needs.check-upstream.outputs.release }}"
+          # Strip the leading 'v' from the upstream release version
+          export latest="${upstream/v/}"
+          # Update the version in the rockcraft.yaml
+          yq -i '.version = env(latest)' rockcraft.yaml
 
       # We use a Github App and token to allow Github Actions to run properly on the created PR.
       - uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92 # v1

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build/
 .coverage
 __pycache__/
 *.py[cod]
+*.rock

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,0 @@
-FROM public.ecr.aws/zinclabs/zinc:0.4.7@sha256:fefa9ee7256a3c9e7a4f95345265ddf03daa912c5662277860bcbbe77088e662 AS builder
-
-FROM ubuntu:latest@sha256:0bced47fffa3361afa981854fcabcd4577cd43cebbb808cea2b1f33a3dd7f508
-COPY --from=builder /go/bin/zincsearch /go/bin/zinc
-
-EXPOSE 4080
-ENTRYPOINT ["/go/bin/zinc"]

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -25,14 +25,16 @@ containers:
     resource: zinc-image
     mounts:
       - storage: data
-        location: /go/bin/data
+        location: /data
+      - storage: logs
+        location: /var/log/zincsearch
 
 resources:
   zinc-image:
     type: oci-image
     description: OCI image for zinc
     # Included for simplicity in integration tests
-    upstream-source: jnsgruk/zinc:0.4.7
+    upstream-source: ghcr.io/jnsgruk/zinc:0.4.7
 
 peers:
   zinc-peers:
@@ -58,3 +60,6 @@ storage:
   data:
     type: filesystem
     location: /zinc-data
+  logs:
+    type: filesystem
+    location: /zinc-logs

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -1,0 +1,76 @@
+name: zinc
+version: 0.4.7
+license: Apache-2.0
+
+base: bare
+build_base: ubuntu:22.04
+platforms:
+  amd64:
+
+summary: Zinc is a lightweight search engine and alternative to Elasticsearch.
+description: |
+  Zinc is a search engine that does full text indexing. It is a lightweight alternative to
+  elasticsearch and runs in less than 100 MB of RAM. It uses bluge as the underlying indexing
+  library.
+
+  It is very simple and easy to operate as opposed to elasticsearch which requires a couple dozen
+  knobs to understand and tune.
+
+  It is a drop-in replacement for elasticsearch if you are just ingesting data using APIs and
+  searching using kibana (Kibana is not supported with zinc. Zinc provides its own UI).
+
+run_user: _daemon_
+
+environment:
+  ZINC_DATA_PATH: /data
+  ZINC_PROMETHEUS_ENABLE: true
+  ZINC_TELEMETRY: false
+  ZINC_PROFILER: true
+
+services:
+  zinc:
+    override: replace
+    startup: enabled
+    command: /bin/zincsearch
+
+parts:
+  zinc:
+    plugin: go
+    source: https://github.com/zincsearch/zincsearch
+    source-type: git
+    source-tag: v0.4.7
+    build-snaps:
+      - go/latest/stable
+      - node/18/stable
+    build-environment:
+      - CGO_ENABLED: 0
+      - GOOS: linux
+    override-build: |
+      COMMIT_HASH="$(git rev-parse HEAD)"
+      BUILD_DATE="$(date -u '+%Y-%m-%d_%I:%M:%S%p-GMT')"
+
+      # Build the web ui, which is embedded in the go binary later
+      pushd web
+      npm install
+      npm run build
+      popd
+
+      go mod tidy
+      go build \
+        -ldflags="-s -w
+        -X github.com/zincsearch/zincsearch/pkg/meta.Version=${CRAFT_PROJECT_VERSION} \
+        -X github.com/zincsearch/zincsearch/pkg/meta.CommitHash=${COMMIT_HASH} \
+        -X github.com/zincsearch/zincsearch/pkg/meta.BuildDate=${BUILD_DATE}" \
+        -o zincsearch \
+        cmd/zincsearch/main.go
+    stage-packages:
+      - libc6_libs
+      - ca-certificates_data
+      # This can be removed once Pebble supports Loki forwarding.
+      - busybox_bins
+    override-stage: |
+      # Create the bin directory and copy the binary into it
+      mkdir -p "${CRAFT_PART_INSTALL}/bin"
+      install -m 0755 "${CRAFT_PART_BUILD}/zincsearch" "${CRAFT_PART_INSTALL}/bin/zincsearch"
+      # Run the default stage hook
+      craftctl default

--- a/src/zinc.py
+++ b/src/zinc.py
@@ -16,7 +16,7 @@ class Zinc:
     """Represent a Zinc instance in the workload."""
 
     _port = 4080
-    _log_path = "/var/log/zinc.log"
+    _log_path = "/var/log/zincsearch/zinc.log"
 
     def pebble_layer(self, initial_password) -> dict:
         """Return a Pebble layer for managing Zinc."""
@@ -25,10 +25,10 @@ class Zinc:
                 "zinc": {
                     "override": "replace",
                     "summary": "zinc",
-                    "command": '/bin/sh -c "/go/bin/zinc | tee {}"'.format(self.log_path),
+                    "command": f"/bin/busybox sh -c '/bin/zincsearch | /bin/busybox tee {self.log_path}'",
                     "startup": "enabled",
                     "environment": {
-                        "ZINC_DATA_PATH": "/go/bin/data",
+                        "ZINC_DATA_PATH": "/data",
                         "ZINC_FIRST_ADMIN_USER": "admin",
                         "ZINC_FIRST_ADMIN_PASSWORD": initial_password,
                         "ZINC_PROMETHEUS_ENABLE": True,

--- a/tests/integration/test_charm_basic.py
+++ b/tests/integration/test_charm_basic.py
@@ -46,7 +46,7 @@ async def test_application_is_up(ops_test: OpsTest):
 @mark.abort_on_fail
 async def test_get_admin_password_action(ops_test: OpsTest):
     password = await _get_password(ops_test)
-    assert re.match("[A-Za-z0-9]{24}", password)
+    assert re.match("[A-Za-z0-9-_]{24}", password)
 
 
 @retry(wait=wexp(multiplier=2, min=1, max=30), stop=stop_after_attempt(10), reraise=True)

--- a/tests/integration/test_ingress_traefik.py
+++ b/tests/integration/test_ingress_traefik.py
@@ -31,7 +31,7 @@ async def test_ingress_traefik_k8s(ops_test, zinc_deploy_kwargs):
     )
 
     # Create the relation
-    await ops_test.model.add_relation(ZINC, TRAEFIK)
+    await ops_test.model.integrate(ZINC, TRAEFIK)
     # Wait for the two apps to quiesce
     await ops_test.model.wait_for_idle(apps=apps, status="active", timeout=1000)
 

--- a/tests/integration/test_observability_relations.py
+++ b/tests/integration/test_observability_relations.py
@@ -32,7 +32,7 @@ async def test_deploy_charms(ops_test, zinc_deploy_kwargs):
 @mark.parametrize("endpoint,remote", list(zip(O11Y_RELS, O11Y_CHARMS)))
 async def test_create_relation(ops_test, endpoint, remote):
     # Create the relation
-    await ops_test.model.add_relation(f"{ZINC}:{endpoint}", remote)
+    await ops_test.model.integrate(f"{ZINC}:{endpoint}", remote)
     # Wait for the two apps to quiesce
     await ops_test.model.wait_for_idle(apps=[ZINC, remote], status="active", timeout=1000)
 

--- a/tests/unit/test_zinc.py
+++ b/tests/unit/test_zinc.py
@@ -17,10 +17,10 @@ class TestCharm(unittest.TestCase):
                 "zinc": {
                     "override": "replace",
                     "summary": "zinc",
-                    "command": '/bin/sh -c "/go/bin/zinc | tee /var/log/zinc.log"',
+                    "command": "/bin/busybox sh -c '/bin/zincsearch | /bin/busybox tee /var/log/zincsearch/zinc.log'",
                     "startup": "enabled",
                     "environment": {
-                        "ZINC_DATA_PATH": "/go/bin/data",
+                        "ZINC_DATA_PATH": "/data",
                         "ZINC_FIRST_ADMIN_USER": "admin",
                         "ZINC_FIRST_ADMIN_PASSWORD": "password",
                         "ZINC_PROMETHEUS_ENABLE": True,


### PR DESCRIPTION
This PR addresses the following:

- Replace the Dockerfile with a rockcraft.yaml
- Update the CI workflows to publish a ROCK to ghcr.io
- Use the ROCK in the charm