### PR TITLE
Add support for Ingress with 'path' routing mode

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -53,7 +53,10 @@ class ZincCharm(ops.CharmBase):
         )
 
         self._ingress = IngressPerAppRequirer(
-            self, host=f"{self.app.name}.{self.model.name}.svc.cluster.local", port=self._zinc.port
+            self,
+            host=f"{self.app.name}.{self.model.name}.svc.cluster.local",
+            port=self._zinc.port,
+            strip_prefix=True,
         )
 
     def _on_zinc_pebble_ready(self, event: ops.WorkloadEvent):

--- a/tests/integration/test_path_ingress_traefik.py
+++ b/tests/integration/test_path_ingress_traefik.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+# Copyright 2021 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import asyncio
+import json
+
+import pytest
+import requests
+
+from . import ZINC
+
+TRAEFIK = "traefik-k8s"
+
+
+@pytest.mark.abort_on_fail
+async def test_path_ingress_traefik_k8s(ops_test, zinc_deploy_kwargs):
+    """Test that Zinc can be related with Traefik for ingress with path routing."""
+    apps = [ZINC, TRAEFIK]
+
+    await asyncio.gather(
+        ops_test.model.deploy(**await zinc_deploy_kwargs),
+        ops_test.model.deploy(
+            TRAEFIK,
+            application_name=TRAEFIK,
+            channel="edge",
+            config={"routing_mode": "path", "external_hostname": "foo.bar"},
+            trust=True,
+        ),
+        ops_test.model.wait_for_idle(apps=apps, status="active", timeout=1000),
+    )
+
+    # Create the relation
+    await ops_test.model.integrate(ZINC, TRAEFIK)
+    # Wait for the two apps to quiesce
+    await ops_test.model.wait_for_idle(apps=apps, status="active", timeout=1000)
+
+    result = await _retrieve_proxied_endpoints(ops_test, TRAEFIK)
+    assert result.get(ZINC, None) == {"url": f"http://foo.bar/{ops_test.model_name}-{ZINC}"}
+
+
+async def test_ingress_functions_correctly(ops_test):
+    status = await ops_test.model.get_status()  # noqa: F821
+    address = status["applications"][TRAEFIK]["public-address"]
+    r = requests.get(
+        f"http://{address}:80/{ops_test.model_name}-{ZINC}/version",
+        headers={"Host": "foo.bar"},
+    )
+
+    assert r.status_code == 200
+    assert "version" in r.json()
+
+
+async def _retrieve_proxied_endpoints(ops_test, traefik_application_name):
+    traefik_application = ops_test.model.applications[traefik_application_name]
+    traefik_first_unit = next(iter(traefik_application.units))
+    action = await traefik_first_unit.run_action("show-proxied-endpoints")
+    await action.wait()
+    result = await ops_test.model.get_action_output(action.id)
+
+    return json.loads(result["proxied-endpoints"])


### PR DESCRIPTION
This PR sets `strip_prefix` to `True`, to allow the ingress integration to work with Traefik set in the `path` routing mode.

If related to Traefik in the `subdomain` routing mode, zinc was reachable at `http://<model>-<app>.<external_hostname>/`.

If Traefik is in the `path` routing mode, zinc will be reachable at `http://<external_hostname>/<model>-<app>/`. The `strip_prefix` set to `True` will allow zinc to receive the traffic with the right path.