### PR TITLE
ci: use `charmcraft test` rather than `actions-operator`

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -43,30 +43,76 @@ jobs:
           credentials: "${{ secrets.CHARMHUB_TOKEN }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
-  integration-test:
-    name: Integration tests (microk8s)
+  pack-charm:
+    name: Build charm
     runs-on: ubuntu-24.04
-    needs:
-      - lint
-      - unit-test
-      - lib-check
     steps:
       - name: Checkout
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
-      # See: https://github.com/charmed-kubernetes/actions-operator/issues/82
-      - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/checkout@v4
+
+      - name: Setup LXD
+        uses: canonical/setup-lxd@main
+
+      - name: Install charmcraft
+        run: sudo snap install charmcraft --classic
+
+      - name: Pack charm
+        run: charmcraft pack -v
+
+      - name: Upload charm artifact
+        uses: actions/upload-artifact@v4
         with:
-          python-version: "3.12"
-      - name: Setup operator environment
-        uses: charmed-kubernetes/actions-operator@main
+          name: charm
+          path: ./*.charm
+
+  define-matrix:
+    name: Define spread matrix
+    runs-on: ubuntu-24.04
+    outputs:
+      suites: ${{ steps.suites.outputs.suites }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install charmcraft
+        run: sudo snap install charmcraft --classic
+
+      - name: Generate matrix list
+        id: suites
+        run: |
+          list="$(charmcraft test --list github-ci | sed "s|github-ci:ubuntu-24.04:tests/spread/||g" | jq -r -ncR '[inputs | select(length>0)]')"
+          echo "suites=$list"
+          echo "suites=$list" >> $GITHUB_OUTPUT
+
+  integration-test:
+    name: Spread (${{ matrix.suite }})
+    runs-on: ubuntu-24.04
+    needs:
+      - define-matrix
+      - lib-check
+      - lint
+      - pack-charm
+      - unit-test
+    strategy:
+      matrix:
+        suite: ${{ fromJSON(needs.define-matrix.outputs.suites) }}
+    # Allow Juju 3.6 jobs to fail, given that it's in beta
+    continue-on-error: ${{ contains(matrix.suite, 'juju_3_6') }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download charm artifact
+        uses: actions/download-artifact@v4
         with:
-          provider: microk8s
-          channel: 1.28-strict/stable
-          juju-channel: 3.5/stable
-          microk8s-group: snap_microk8s
-          microk8s-addons: "hostpath-storage dns metallb:10.64.140.43-10.64.140.49"
-      - name: Install dependencies
-        run: sudo snap install --classic astral-uv
+          name: charm
+
+      - name: Setup LXD
+        uses: canonical/setup-lxd@main
+
+      - name: Install charmcraft
+        run: sudo snap install charmcraft --classic
+
       - name: Run integration tests
-        run: make integration
+        run: |
+          charmcraft test -v "github-ci:ubuntu-24.04:tests/spread/${{ matrix.suite }}"

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ __pycache__/
 .vscode/*
 *.egg-info/
 requirements*.txt
+.spread*

--- a/spread.yaml
+++ b/spread.yaml
@@ -1,0 +1,108 @@
+project: zinc-charm-tests
+
+environment:
+  JUJU_CHANNEL/juju_3_5: 3.5/stable
+  JUJU_CHANNEL/juju_3_6: 3.6/beta
+  CHARMCRAFT_CHANNEL: latest/stable
+  LXD_CHANNEL: latest/stable
+  MICROK8S_CHANNEL: 1.31-strict/stable
+  PROVIDER: microk8s
+
+  MICROK8S_ADDONS: hostpath-storage dns
+  METALLB_RANGE: 10.64.140.43-10.64.140.49
+
+  JUJU_BOOTSTRAP_OPTIONS: --model-default test-mode=true --model-default automatically-retry-hooks=false
+  JUJU_EXTRA_BOOTSTRAP_OPTIONS: ""
+  JUJU_BOOTSTRAP_CONSTRAINTS: ""
+
+  LANG: "C.UTF-8"
+  LANGUAGE: "en"
+
+  PROJECT_PATH: /home/spread/proj
+  CRAFT_TEST_PATH: /home/spread/proj/tests/spread/lib
+
+backends:
+  lxd:
+    type: adhoc
+    allocate: |
+      BASE="${BASE:-noble}"
+      VM_NAME="${VM_NAME:-ubuntu-${BASE}-${RANDOM}}"
+      DISK="${DISK:-20}"
+      CPU="${CPU:-4}"
+      MEM="${MEM:-8}"
+
+      lxc launch --vm \
+        "ubuntu:${BASE}" \
+        "${VM_NAME}" \
+        -c user.user-data="$(cat tests/spread/lib/cloud-config.yaml)" \
+        -c limits.cpu="${CPU}" \
+        -c limits.memory="${MEM}GiB" \
+        -d root,size="${DISK}GiB"
+
+      # Wait for the spread user
+      while ! lxc exec "${VM_NAME}" -- id -u spread &>/dev/null; do sleep 0.5; done
+
+      # Set the instance address for spread
+      ADDRESS "$(lxc ls -f csv | grep "${VM_NAME}" | cut -d"," -f3 | cut -d" " -f1)"
+    discard: |
+      instance_name="$(lxc ls -f csv | grep $SPREAD_SYSTEM_ADDRESS | cut -f1 -d",")"
+      lxc delete -f $instance_name
+
+    systems:
+      - ubuntu-24.04:
+          username: spread
+          password: spread
+          workers: 1
+
+  github-ci:
+    type: adhoc
+    manual: true
+    allocate: |
+      sudo sed -i "s|#PasswordAuthentication yes|PasswordAuthentication yes|g" /etc/ssh/sshd_config
+      sudo sed -i "s|KbdInteractiveAuthentication no|KbdInteractiveAuthentication yes|g" /etc/ssh/sshd_config
+      sudo rm -f /etc/ssh/sshd_config.d/60-cloudimg-settings.conf
+      sudo systemctl daemon-reload
+      sudo systemctl restart ssh
+
+      sudo useradd spread -s /bin/bash -m || true
+      echo "spread:spread" | sudo chpasswd || true
+      echo 'spread ALL=(ALL) NOPASSWD:ALL ' | sudo tee /etc/sudoers.d/99-spread-user || true
+
+      ADDRESS "127.0.0.1"
+    discard: |
+      sudo userdel -f -r spread || true
+      sudo rm -f /etc/sudoers.d/99-spread-user
+
+    systems:
+      - ubuntu-24.04:
+          username: spread
+          password: spread
+          workers: 1
+
+suites:
+  tests/spread/:
+    summary: Spread tests
+
+exclude:
+  - .git
+  - .tox
+  - .ruff_cache
+  - .coverage
+
+path: /home/spread/proj
+
+prepare: |
+  snap refresh --hold
+  if systemctl is-enabled unattended-upgrades.service; then
+    systemctl stop unattended-upgrades.service
+    systemctl mask unattended-upgrades.service
+  fi
+
+restore: |
+  apt autoremove -y --purge
+  rm -Rf "$PROJECT_PATH"
+  mkdir -p "$PROJECT_PATH"
+
+kill-timeout: 15m
+
+workers: 1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,8 @@
-# Copyright 2021 Canonical Ltd.
-# See LICENSE file for licensing details.
 from _pytest.config.argparsing import Parser
 
 
 def pytest_addoption(parser: Parser):
     parser.addoption(
-        "--channel",
-        help="Zinc channel to deploy for integration tests. If absent"
-        "the zinc charm will be built from source.",
+        "--charm-path",
+        help="Pre-built charm file to deploy, rather than building from source",
     )

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -11,8 +11,12 @@ logger = logging.getLogger(__name__)
 
 
 @fixture(scope="module")
-async def zinc_charm(ops_test: OpsTest):
+async def zinc_charm(request, ops_test: OpsTest):
     """Zinc charm used for integration testing."""
+    charm_file = request.config.getoption("--charm-path")
+    if charm_file:
+        return charm_file
+
     charm = await ops_test.build_charm(".")
     return charm
 

--- a/tests/spread/deploy/task.yaml
+++ b/tests/spread/deploy/task.yaml
@@ -1,0 +1,23 @@
+summary: Run basic deployment tests
+kill-timeout: 60m
+systems:
+  - ubuntu-24.04
+
+prepare: |
+  . "${CRAFT_TEST_PATH}/common.sh"
+  setup_test_environment
+
+execute: |
+  pushd "$PROJECT_PATH"
+  args="tests/integration/test_charm_basic.py"
+
+  if [[ -f "$PWD/zinc-k8s_amd64.charm" ]]; then
+    args="--charm-path=$PWD/zinc-k8s_amd64.charm $args"
+  fi
+
+  make integration ARGS="$args"
+  popd
+
+restore: |
+  . "${CRAFT_TEST_PATH}/common.sh"
+  restore_test_environment

--- a/tests/spread/ingress-path/task.yaml
+++ b/tests/spread/ingress-path/task.yaml
@@ -1,0 +1,23 @@
+summary: Deploy with traefik ingress in path routing mode
+kill-timeout: 60m
+systems:
+  - ubuntu-24.04
+
+prepare: |
+  . "${CRAFT_TEST_PATH}/common.sh"
+  setup_test_environment
+
+execute: |
+  pushd "$PROJECT_PATH"
+  args="tests/integration/test_path_ingress_traefik.py"
+
+  if [[ -f "$PWD/zinc-k8s_amd64.charm" ]]; then
+    args="--charm-path=$PWD/zinc-k8s_amd64.charm $args"
+  fi
+
+  make integration ARGS="$args"
+  popd
+
+restore: |
+  . "${CRAFT_TEST_PATH}/common.sh"
+  restore_test_environment

--- a/tests/spread/ingress/task.yaml
+++ b/tests/spread/ingress/task.yaml
@@ -1,0 +1,23 @@
+summary: Deploy with traefik ingress in subdomain routing mode
+kill-timeout: 60m
+systems:
+  - ubuntu-24.04
+
+prepare: |
+  . "${CRAFT_TEST_PATH}/common.sh"
+  setup_test_environment
+
+execute: |
+  pushd "$PROJECT_PATH"
+  args="tests/integration/test_ingress_traefik.py"
+
+  if [[ -f "$PWD/zinc-k8s_amd64.charm" ]]; then
+    args="--charm-path=$PWD/zinc-k8s_amd64.charm $args"
+  fi
+
+  make integration ARGS="$args"
+  popd
+
+restore: |
+  . "${CRAFT_TEST_PATH}/common.sh"
+  restore_test_environment

--- a/tests/spread/lib/cloud-config.yaml
+++ b/tests/spread/lib/cloud-config.yaml
@@ -1,0 +1,10 @@
+#cloud-config
+
+ssh_pwauth: true
+
+users:
+  - default
+  - name: spread
+    plain_text_passwd: spread
+    lock_passwd: false
+    sudo: ALL=(ALL) NOPASSWD:ALL

--- a/tests/spread/lib/common.sh
+++ b/tests/spread/lib/common.sh
@@ -1,0 +1,75 @@
+export PATH=/snap/bin:$PROJECT_PATH/tests/spread/lib/tools:$PATH
+export CONTROLLER_NAME="craft-test-$PROVIDER"
+
+install_lxd() {
+    snap install lxd --channel "$LXD_CHANNEL"
+    snap refresh lxd --channel "$LXD_CHANNEL"
+    lxd waitready
+    lxd init --minimal
+    chmod a+wr /var/snap/lxd/common/lxd/unix.socket
+    lxc network set lxdbr0 ipv6.address none
+    usermod -a -G lxd "$USER"
+
+    iptables -F FORWARD
+    iptables -P FORWARD ACCEPT
+}
+
+install_microk8s() {
+    snap install microk8s --channel "$MICROK8S_CHANNEL"
+    snap refresh microk8s --channel "$MICROK8S_CHANNEL"
+    microk8s status --wait-ready
+
+    if [ ! -z "$MICROK8S_ADDONS" ]; then
+        microk8s enable $MICROK8S_ADDONS
+    fi
+
+    microk8s enable metallb:"$METALLB_RANGE"
+
+    microk8s kubectl wait --for=condition=available --timeout=5m -nkube-system deployment/coredns deployment/hostpath-provisioner
+    microk8s kubectl auth can-i create pods
+}
+
+install_juju() {
+    snap install juju --classic --channel "$JUJU_CHANNEL"
+    mkdir -p "$HOME"/.local/share/juju
+}
+
+bootstrap_juju() {
+    agent_version="$(snap info juju | grep "$JUJU_CHANNEL" | tr "\n" " " | tr -s " " | cut -d " " -f4)"
+
+    juju bootstrap --verbose "$PROVIDER" "$CONTROLLER_NAME" \
+      $JUJU_BOOTSTRAP_OPTIONS $JUJU_EXTRA_BOOTSTRAP_OPTIONS \
+      --bootstrap-constraints=$JUJU_BOOTSTRAP_CONSTRAINTS \
+      --agent-version="$agent_version"
+}
+
+install_tools() {
+    apt-get install -y make
+    snap install astral-uv --classic
+    snap install charmcraft --classic --channel "$CHARMCRAFT_CHANNEL"
+    snap install jq
+    snap install kubectl --classic
+    mkdir -p "$HOME"/.kube
+    microk8s config > ${HOME}/.kube/config
+}
+
+setup_test_environment() {
+  install_lxd
+  install_juju
+  install_microk8s
+  install_tools
+  bootstrap_juju
+  juju add-model testing
+}
+
+restore_test_environment() {
+  rm -rf "$HOME"/.kube
+  rm -rf "$HOME"/.local/share/juju
+
+  snap remove --purge astral-uv
+  snap remove --purge charmcraft
+  snap remove --purge jq
+  snap remove --purge juju
+  snap remove --purge kubectl
+  snap remove --purge microk8s
+}

--- a/tests/spread/observability-relations/task.yaml
+++ b/tests/spread/observability-relations/task.yaml
@@ -1,0 +1,23 @@
+summary: Test observability relations with zinc
+kill-timeout: 60m
+systems:
+  - ubuntu-24.04
+
+prepare: |
+  . "${CRAFT_TEST_PATH}/common.sh"
+  setup_test_environment
+
+execute: |
+  pushd "$PROJECT_PATH"
+  args="tests/integration/test_observability_relations.py"
+
+  if [[ -f "$PWD/zinc-k8s_amd64.charm" ]]; then
+    args="--charm-path=$PWD/zinc-k8s_amd64.charm $args"
+  fi
+
+  make integration ARGS="$args"
+  popd
+
+restore: |
+  . "${CRAFT_TEST_PATH}/common.sh"
+  restore_test_environment


### PR DESCRIPTION
Early draft that converts this charm to use `charmcraft test`, rather than `actions-operator`.

This means that one can, locally:

```bash
# Clone the repo
❯ git clone -b craft-test https://github.com/jnsgruk/zinc-k8s-operator
❯ cd zinc-k8s-operator

# List available tests
❯ charmcraft test --list lxd
github-ci:ubuntu-24.04:tests/spread/deploy:juju_3_6
github-ci:ubuntu-24.04:tests/spread/deploy:juju_3_5
github-ci:ubuntu-24.04:tests/spread/ingress-path:juju_3_5
github-ci:ubuntu-24.04:tests/spread/ingress-path:juju_3_6
github-ci:ubuntu-24.04:tests/spread/ingress:juju_3_5
github-ci:ubuntu-24.04:tests/spread/ingress:juju_3_6
github-ci:ubuntu-24.04:tests/spread/observability-relations:juju_3_5
github-ci:ubuntu-24.04:tests/spread/observability-relations:juju_3_6

# Run the test suites, each in their own VM
❯ charmcraft test -v lxd

# Run a specific test suite in a LXD VM
❯ charmcraft test -v lxd:ubuntu-24.04:tests/spread/deploy:juju_3_5
```

Which will spin up a local LXD VM for each of the test suites listed, and run them. Note that there are multiple variants defined (`juju_3_6`, `juju_3_5`), which are all defined in the top-level `spread.yaml` using the `JUJU_CHANNEL/3_5` and `JUJU_CHANNEL/3_6` notation. Adding another variant to each would be as simple as adding a line such as `JUJU_CHANNEL/4_0: 4.0/beta`.

In CI, we do something different, and use spread to just run the tests directly on the CI runner with `charmcraft test local:`, which uses an ad-hoc local backend which causes `spread` to ssh into the system it's running on! In this case, I've chosen to generate this matrix dynamically using `charmcraft list local`, then mangle that into a matrix we can use with Github natively -- the other way to do this is to give `spread` some credentials to a cloud and just run `charmcraft test openstack`, for example, and it'll go and fan out the number of VMs required.

This WIP also includes the addition of a `continue-on-error` for the Juju 3.6 testing. I think this is important for us to incorporate going forward: centrally introducing non-blocking test runs for new versions of Juju, such that teams get a heads up if an RC is going to break them, and the Juju team can get more signal about how their upcoming builds might affect the charm teams.

I think this gets us closer to having the same experience locally, and in CI, and should make iteration time faster for our developers. There is the option to not destroy the provisioned test vms in between runs on the local machine with:

```
charmcraft.spread -reuse lxd
```

Worth noting that the setup of the machine here is done by a bash script and some associated common functions in `common.sh`, but in the long run that script could be:

- Centrally hosted and re-used between teams (better, but not ideal)
- Converted into a charm-test-setup snap that we can all use, and encapsulates the logic of setting up the machines with some parameters, e.g.:

```bash
charm-test-setup --juju-channel 3.4/stable --microk8s-channel 1.31-strict/stable ...
```

(Probably not the end experience we desire, but hopefully makes my point!)

Feedback welcome, we'll be iterating on this experience in the coming weeks/months!