### PR TITLE
ci: combine Github Actions Cache with the charmcraft cache

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -56,6 +56,13 @@ jobs:
       - name: Install charmcraft
         run: sudo snap install charmcraft --classic
 
+      - name: Cache wheels
+        id: cache-wheels
+        uses: actions/cache@v4
+        with:
+          path: /home/runner/snap/charmcraft/common/cache/charmcraft
+          key: ${{ runner.os }}-wheel-cache-${{ hashFiles('./uv.lock') }}
+
       - name: Pack charm
         run: charmcraft pack -v
 


### PR DESCRIPTION
Charmcraft has the ability to cache wheels that are built during the charm build process, and use those built wheels across `pack` invocations - which should dramatically reduce the build time of the charm where the dependencies don't change.

This commit introduces the use of that cache by combining it with Github Actions' built in cache, in the hope that the CI can be sped up in the average case.