### PR TITLE
test: don't restore test vms in CI

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -18,6 +18,7 @@ environment:
   LANG: "C.UTF-8"
   LANGUAGE: "en"
 
+  CI: "$(HOST: echo $CI)"
   PROJECT_PATH: /root/proj
   CRAFT_TEST_PATH: /root/proj/tests/spread/lib
 
@@ -105,9 +106,11 @@ prepare: |
   fi
 
 restore: |
-  apt autoremove -y --purge
-  rm -Rf "$PROJECT_PATH"
-  mkdir -p "$PROJECT_PATH"
+  if [[ -z "${CI:-}" ]]; then
+    apt autoremove -y --purge
+    rm -Rf "$PROJECT_PATH"
+    mkdir -p "$PROJECT_PATH"
+  fi
 
 kill-timeout: 15m
 

--- a/tests/spread/deploy/task.yaml
+++ b/tests/spread/deploy/task.yaml
@@ -20,5 +20,7 @@ execute: |
   popd
 
 restore: |
-  . "${CRAFT_TEST_PATH}/common.sh"
-  restore_test_environment
+  if [[ -z "${CI:-}" ]]; then
+    . "${CRAFT_TEST_PATH}/common.sh"
+    restore_test_environment
+  fi

--- a/tests/spread/ingress-path/task.yaml
+++ b/tests/spread/ingress-path/task.yaml
@@ -20,5 +20,7 @@ execute: |
   popd
 
 restore: |
-  . "${CRAFT_TEST_PATH}/common.sh"
-  restore_test_environment
+  if [[ -z "${CI:-}" ]]; then
+    . "${CRAFT_TEST_PATH}/common.sh"
+    restore_test_environment
+  fi

--- a/tests/spread/ingress/task.yaml
+++ b/tests/spread/ingress/task.yaml
@@ -20,5 +20,7 @@ execute: |
   popd
 
 restore: |
-  . "${CRAFT_TEST_PATH}/common.sh"
-  restore_test_environment
+  if [[ -z "${CI:-}" ]]; then
+    . "${CRAFT_TEST_PATH}/common.sh"
+    restore_test_environment
+  fi

--- a/tests/spread/lib/common.sh
+++ b/tests/spread/lib/common.sh
@@ -1,19 +1,6 @@
 export PATH=/snap/bin:$PROJECT_PATH/tests/spread/lib/tools:$PATH
 export CONTROLLER_NAME="craft-test-$PROVIDER"
 
-install_lxd() {
-    snap install lxd --channel "$LXD_CHANNEL"
-    snap refresh lxd --channel "$LXD_CHANNEL"
-    lxd waitready
-    lxd init --minimal
-    chmod a+wr /var/snap/lxd/common/lxd/unix.socket
-    lxc network set lxdbr0 ipv6.address none
-    usermod -a -G lxd "$USER"
-
-    iptables -F FORWARD
-    iptables -P FORWARD ACCEPT
-}
-
 install_microk8s() {
     snap install microk8s --channel "$MICROK8S_CHANNEL"
     snap refresh microk8s --channel "$MICROK8S_CHANNEL"
@@ -47,14 +34,12 @@ install_tools() {
     apt-get install -y make
     snap install astral-uv --classic
     snap install charmcraft --classic --channel "$CHARMCRAFT_CHANNEL"
-    snap install jq
     snap install kubectl --classic
     mkdir -p "$HOME"/.kube
     microk8s config > ${HOME}/.kube/config
 }
 
 setup_test_environment() {
-  install_lxd
   install_juju
   install_microk8s
   install_tools
@@ -68,7 +53,6 @@ restore_test_environment() {
 
   snap remove --purge astral-uv
   snap remove --purge charmcraft
-  snap remove --purge jq
   snap remove --purge juju
   snap remove --purge kubectl
   snap remove --purge microk8s

--- a/tests/spread/observability-relations/task.yaml
+++ b/tests/spread/observability-relations/task.yaml
@@ -20,5 +20,7 @@ execute: |
   popd
 
 restore: |
-  . "${CRAFT_TEST_PATH}/common.sh"
-  restore_test_environment
+  if [[ -z "${CI:-}" ]]; then
+    . "${CRAFT_TEST_PATH}/common.sh"
+    restore_test_environment
+  fi


### PR DESCRIPTION
Spread will automatically "restore" test VMs after a test, which in normal cases is desierable, but in CI the machines get discarded right away, with no further jobs, so it's just wasting time.