### PR TITLE
build: migrate to the `python` plugin

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -54,7 +54,7 @@ jobs:
         uses: canonical/setup-lxd@main
 
       - name: Install charmcraft
-        run: sudo snap install charmcraft --classic
+        run: sudo snap install charmcraft --classic --channel latest/edge
 
       - name: Cache wheels
         id: cache-wheels

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -22,28 +22,18 @@ platforms:
   amd64:
 
 parts:
-  charm:
+  zinc-charm:
+    plugin: python
+    source: .
+    override-pull: |
+      craftctl default
+      rustup toolchain install stable
+      make generate-requirements
+    python-requirements:
+      - requirements.txt
     build-snaps:
       - rustup
       - astral-uv
-    override-build: |
-      rustup toolchain install stable
-      make generate-requirements
-      craftctl default
-    prime:
-      - -*.charm
-      - -spread.yaml
-      - -rockcraft.yaml
-      - -.venv
-      - -CONTRIBUTING.md
-      - -Makefile
-      - -pyproject.toml
-      - -README.md
-      - -requirements-dev.txt
-      - -scripts/
-      - -tests/
-      - -uv.lock
-      - -src/zinc_k8s_operator.egg-info
 
 assumes:
   - juju >= 3.1

--- a/spread.yaml
+++ b/spread.yaml
@@ -4,6 +4,7 @@ workers: 1
 
 environment:
   CI: "$(HOST: echo $CI)"
+  CONCIERGE_CHARMCRAFT_CHANNEL: latest/edge
   CONCIERGE_JUJU_CHANNEL/juju_3_5: 3.5/stable
   CONCIERGE_JUJU_CHANNEL/juju_3_6: 3.6/stable
 


### PR DESCRIPTION
As per: https://github.com/canonical/charmcraft/pull/1967