### PR TITLE
test: wait for Traefik load balancer IP

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -3,6 +3,8 @@
 
 import os
 import subprocess
+import time
+from collections.abc import Callable
 from pathlib import Path
 
 import jubilant
@@ -45,26 +47,51 @@ def zinc_oci_image():
     return meta["resources"]["zinc-image"]["upstream-source"]
 
 
+def _get_traefik_lb_ip(
+    model_name: str,
+    *,
+    run: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+    sleep: Callable[[int], None] = time.sleep,
+    attempts: int = 24,
+    retry_sleep_sec: int = 5,
+) -> str:
+    """Wait for Traefik's LoadBalancer service to be assigned a usable address."""
+
+    def _kubectl_service_jsonpath(jsonpath: str) -> str:
+        proc = run(
+            [
+                "/snap/bin/kubectl",
+                "-n",
+                model_name,
+                "get",
+                "service",
+                f"{TRAEFIK}-lb",
+                f"-o=jsonpath={jsonpath}",
+            ],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        return proc.stdout.strip().strip("'")
+
+    for attempt in range(attempts):
+        ip_address = _kubectl_service_jsonpath("{.status.loadBalancer.ingress[0].ip}")
+        if ip_address:
+            return ip_address
+
+        if attempt < attempts - 1:
+            sleep(retry_sleep_sec)
+
+    if cluster_ip := _kubectl_service_jsonpath("{.spec.clusterIP}"):
+        return cluster_ip
+
+    raise AssertionError("Traefik service address was not assigned")
+
+
 @fixture(scope="module")
 def traefik_lb_ip(juju: jubilant.Juju):
     model_name = juju.model
     assert model_name is not None
 
-    proc = subprocess.run(
-        [
-            "/snap/bin/kubectl",
-            "-n",
-            model_name,
-            "get",
-            "service",
-            f"{TRAEFIK}-lb",
-            "-o=jsonpath='{.status.loadBalancer.ingress[0].ip}'",
-        ],
-        check=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-    )
-
-    ip_address = proc.stdout.strip("'")
-    return ip_address
+    return _get_traefik_lb_ip(model_name)

--- a/tests/unit/test_ingress_helpers.py
+++ b/tests/unit/test_ingress_helpers.py
@@ -1,0 +1,71 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import subprocess
+
+import pytest
+
+from tests.integration.conftest import _get_traefik_lb_ip
+
+
+def test_get_traefik_lb_ip_waits_until_service_has_ip():
+    """Return the first non-empty Traefik LoadBalancer IP."""
+    calls = []
+    outputs = ["", "'10.1.2.3'"]
+
+    def fake_run(command, **kwargs):
+        calls.append((command, kwargs))
+        return subprocess.CompletedProcess(command, 0, stdout=outputs.pop(0), stderr="")
+
+    sleeps = []
+
+    assert _get_traefik_lb_ip("test-model", run=fake_run, sleep=sleeps.append) == "10.1.2.3"
+    assert sleeps == [5]
+    assert len(calls) == 2
+    assert calls[0][0] == [
+        "/snap/bin/kubectl",
+        "-n",
+        "test-model",
+        "get",
+        "service",
+        "traefik-k8s-lb",
+        "-o=jsonpath={.status.loadBalancer.ingress[0].ip}",
+    ]
+    assert calls[0][1]["check"] is True
+    assert calls[0][1]["stdout"] is subprocess.PIPE
+    assert calls[0][1]["stderr"] is subprocess.PIPE
+    assert calls[0][1]["text"] is True
+
+
+def test_get_traefik_lb_ip_uses_cluster_ip_if_lb_ip_never_appears():
+    """Fall back to the service ClusterIP if MetalLB never assigns a LoadBalancer IP."""
+    commands = []
+
+    def fake_run(command, **kwargs):
+        commands.append(command)
+        if command[-1] == "-o=jsonpath={.spec.clusterIP}":
+            return subprocess.CompletedProcess(command, 0, stdout="10.152.183.42", stderr="")
+        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+    address = _get_traefik_lb_ip("test-model", run=fake_run, sleep=lambda _: None, attempts=2)
+
+    assert address == "10.152.183.42"
+    assert commands[-1] == [
+        "/snap/bin/kubectl",
+        "-n",
+        "test-model",
+        "get",
+        "service",
+        "traefik-k8s-lb",
+        "-o=jsonpath={.spec.clusterIP}",
+    ]
+
+
+def test_get_traefik_lb_ip_fails_clearly_if_no_service_address_appears():
+    """Raise a clear failure when neither LoadBalancer IP nor ClusterIP appears."""
+
+    def fake_run(command, **kwargs):
+        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+    with pytest.raises(AssertionError, match="Traefik service address was not assigned"):
+        _get_traefik_lb_ip("test-model", run=fake_run, sleep=lambda _: None, attempts=2)


### PR DESCRIPTION
## Summary
- Extract Traefik service address lookup into a helper used by the integration fixture
- Retry for a Traefik LoadBalancer IP before ingress tests attempt requests
- Fall back to the service ClusterIP if the LoadBalancer IP is never assigned in the MicroK8s test environment
- Add unit coverage for retry, fallback, and failure behaviour

## Test plan
- `PYTHONPATH=$PWD:$PWD/lib:$PWD/src uv run --all-extras pytest tests/unit/test_ingress_helpers.py -q`
- `PYTHONPATH=$PWD:$PWD/lib:$PWD/src uv run --all-extras pytest tests/unit -q`
- `uv tool run ruff check tests/integration/conftest.py tests/unit/test_ingress_helpers.py`
- `uv tool run ruff format --check --diff tests/integration/conftest.py tests/unit/test_ingress_helpers.py`
- `PYTHONPATH=$PWD:$PWD/lib:$PWD/src make unit`

@jnsgruk